### PR TITLE
Chore: Gradle Dependency 수정

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -50,6 +50,7 @@ jobs:
           reporter: github-pr-review
           fail_on_error: true
           level: warning
+          ktlint_version: 1.3.1
 
         # 유닛 테스트 후 PR 코멘트로 결과 전송
       - name: Run Unit Test

--- a/.github/workflows/weekly_dev.yml
+++ b/.github/workflows/weekly_dev.yml
@@ -49,6 +49,7 @@ jobs:
           reporter: github-pr-review
           fail_on_error: true
           level: warning
+          ktlint_version: 1.3.1
 
         # 유닛 테스트 후 PR 코멘트로 결과 전송
       - name: Run Unit Test

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,6 +7,10 @@ plugins {
     id("com.google.dagger.hilt.android")
 }
 
+ktlint {
+    version.set("1.3.1")
+}
+
 android {
     namespace = "com.kappzzang.jeongsan"
     compileSdk = 34


### PR DESCRIPTION

## ⚠️ 문제점
향후 PR 시 Ktlint를 통해 Convention Check를 진행하는데요,

현재 로컬 환경에서 의존하는 Ktlint 버전과 Git Action에서 사용하는 Ktlint 버전이 일치하지 않습니다.

컨벤션 규칙 또한 달라서 로컬에서 ktlintcheck이 통과해도 CI 프로세스에서는 Fail이 발생할 수 있습니다.


## 💡 해결책
Gradle 종속성과 워크플로우를 약간 수정해서 앞으로 로컬 환경과 CI에서 ktlint 1.3.1 버전을 사용하게 수정하였습니다. 