### PR TITLE
Hotfix: CI 캐싱 문제 해결

### DIFF
--- a/.github/workflows/post_merge_caching.yml
+++ b/.github/workflows/post_merge_caching.yml
@@ -64,4 +64,4 @@ jobs:
         # Gradle 빌드
       - name: Build
         if: success() || failure()
-        run: ./gradlew build --no-daemon
+        run: ./gradlew build --no-daemon -x test -x lintVitalRelease -x lint -x lintVitalSourceSets


### PR DESCRIPTION
브랜치로 머지 후 캐싱 작업을 수행하는 워크플로우가 테스트 도중에 실패하는 현상이 발생중입니다.

해당 Fix에서 캐싱 작업을 수행할 때에는 테스트를 실행하지 않게 수정하였습니다.