### PR TITLE
Hotfix: Merge시 빌드 실패 오류 해결

### DIFF
--- a/.github/workflows/post_merge_caching.yml
+++ b/.github/workflows/post_merge_caching.yml
@@ -64,4 +64,4 @@ jobs:
         # Gradle 빌드
       - name: Build
         if: success() || failure()
-        run: ./gradlew build --no-daemon -x test -x lintVitalRelease -x lint -x lintVitalSourceSets
+        run: ./gradlew build --no-daemon -x test -x lintVitalRelease -x lint -x lintDebug


### PR DESCRIPTION
Merge할 때 빌드가 실패하는 오류를 수정했습니다.

잘못된 파라미터는 없애고, 오류를 유발하는 작업을 생략하는 파라미터를 추가했습니다.