### PR TITLE
Fix: 워크플로에서 Git Secrets 불러오는 스크립트 추가

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -40,22 +40,10 @@ jobs:
 
       - name: Setup Secret Keys
         run: |
-          echo "KAKAO_REST_API_KEY=\"$KAKAO_REST_API_KEY\"" >> local.properties
-          echo "KAKAO_API_KEY=\"$KAKAO_API_KEY\"" >> local.properties
-          echo "KAKAO_API_KEY_MANIFEST=\"$KAKAO_API_KEY_MANIFEST\"" >> local.properties
-          echo "KAKAO_API_URL=\"$KAKAO_API_URL\"" >> local.properties
-          echo "KAKAO_AUTH_URL=\"$KAKAO_AUTH_URL\"" >> local.properties
-          echo "SERVICE_URL=\"$SERVICE_URL\"" >> local.properties
-          echo "KEYSTORE_NAME=\"$KEYSTORE_NAME\"" >> local.properties
+          echo "$LOCAL_PROPERTIES" >> local.properties
         shell: bash
         env:
-          KAKAO_REST_API_KEY: ${{secrets.KAKAO_REST_API_KEY}}
-          KAKAO_API_KEY: ${{secrets.KAKAO_API_KEY}}
-          KAKAO_API_KEY_MANIFEST: ${{secrets.KAKAO_API_KEY_MANIFEST}}
-          KAKAO_API_URL: ${{secrets.KAKAO_API_URL}}
-          KAKAO_AUTH_URL: ${{secrets.KAKAO_AUTH_URL}}
-          SERVICE_URL: ${{secrets.SERVICE_URL}}
-          KEYSTORE_NAME: ${{secrets.KEYSTORE_NAME}}
+          LOCAL_PROPERTIES: ${{ secrets.PROPERTIES }}
 
         # Gradle 스크립트 실행을 위한 권한 설정
       - name: Grant Execute Permission for Gradlew

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -38,6 +38,25 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
+      - name: Setup Secret Keys
+        run: |
+          echo "KAKAO_REST_API_KEY=\"$KAKAO_REST_API_KEY\"" >> local.properties
+          echo "KAKAO_API_KEY=\"$KAKAO_API_KEY\"" >> local.properties
+          echo "KAKAO_API_KEY_MANIFEST=\"$KAKAO_API_KEY_MANIFEST\"" >> local.properties
+          echo "KAKAO_API_URL=\"$KAKAO_API_URL\"" >> local.properties
+          echo "KAKAO_AUTH_URL=\"$KAKAO_AUTH_URL\"" >> local.properties
+          echo "SERVICE_URL=\"$SERVICE_URL\"" >> local.properties
+          echo "KEYSTORE_NAME=\"$KEYSTORE_NAME\"" >> local.properties
+        shell: bash
+        env:
+          KAKAO_REST_API_KEY: ${{secrets.KAKAO_REST_API_KEY}}
+          KAKAO_API_KEY: ${{secrets.KAKAO_API_KEY}}
+          KAKAO_API_KEY_MANIFEST: ${{secrets.KAKAO_API_KEY_MANIFEST}}
+          KAKAO_API_URL: ${{secrets.KAKAO_API_URL}}
+          KAKAO_AUTH_URL: ${{secrets.KAKAO_AUTH_URL}}
+          SERVICE_URL: ${{secrets.SERVICE_URL}}
+          KEYSTORE_NAME: ${{secrets.KEYSTORE_NAME}}
+
         # Gradle 스크립트 실행을 위한 권한 설정
       - name: Grant Execute Permission for Gradlew
         run: chmod +x gradlew

--- a/.github/workflows/post_merge_caching.yml
+++ b/.github/workflows/post_merge_caching.yml
@@ -61,6 +61,26 @@ jobs:
           profile: Nexus 6
           script: echo "Generated AVD snapshot for caching."
 
+      - name: Setup Secret Keys
+        run: |
+          echo "KAKAO_REST_API_KEY=\"$KAKAO_REST_API_KEY\"" >> local.properties
+          echo "KAKAO_API_KEY=\"$KAKAO_API_KEY\"" >> local.properties
+          echo "KAKAO_API_KEY_MANIFEST=\"$KAKAO_API_KEY_MANIFEST\"" >> local.properties
+          echo "KAKAO_API_URL=\"$KAKAO_API_URL\"" >> local.properties
+          echo "KAKAO_AUTH_URL=\"$KAKAO_AUTH_URL\"" >> local.properties
+          echo "SERVICE_URL=\"$SERVICE_URL\"" >> local.properties
+          echo "KEYSTORE_NAME=\"$KEYSTORE_NAME\"" >> local.properties
+        shell: bash
+        env:
+          KAKAO_REST_API_KEY: ${{secrets.KAKAO_REST_API_KEY}}
+          KAKAO_API_KEY: ${{secrets.KAKAO_API_KEY}}
+          KAKAO_API_KEY_MANIFEST: ${{secrets.KAKAO_API_KEY_MANIFEST}}
+          KAKAO_API_URL: ${{secrets.KAKAO_API_URL}}
+          KAKAO_AUTH_URL: ${{secrets.KAKAO_AUTH_URL}}
+          SERVICE_URL: ${{secrets.SERVICE_URL}}
+          KEYSTORE_NAME: ${{secrets.KEYSTORE_NAME}}
+
+
         # Gradle 빌드
       - name: Build
         if: success() || failure()

--- a/.github/workflows/post_merge_caching.yml
+++ b/.github/workflows/post_merge_caching.yml
@@ -63,22 +63,10 @@ jobs:
 
       - name: Setup Secret Keys
         run: |
-          echo "KAKAO_REST_API_KEY=\"$KAKAO_REST_API_KEY\"" >> local.properties
-          echo "KAKAO_API_KEY=\"$KAKAO_API_KEY\"" >> local.properties
-          echo "KAKAO_API_KEY_MANIFEST=\"$KAKAO_API_KEY_MANIFEST\"" >> local.properties
-          echo "KAKAO_API_URL=\"$KAKAO_API_URL\"" >> local.properties
-          echo "KAKAO_AUTH_URL=\"$KAKAO_AUTH_URL\"" >> local.properties
-          echo "SERVICE_URL=\"$SERVICE_URL\"" >> local.properties
-          echo "KEYSTORE_NAME=\"$KEYSTORE_NAME\"" >> local.properties
+          echo "$LOCAL_PROPERTIES" >> local.properties
         shell: bash
         env:
-          KAKAO_REST_API_KEY: ${{secrets.KAKAO_REST_API_KEY}}
-          KAKAO_API_KEY: ${{secrets.KAKAO_API_KEY}}
-          KAKAO_API_KEY_MANIFEST: ${{secrets.KAKAO_API_KEY_MANIFEST}}
-          KAKAO_API_URL: ${{secrets.KAKAO_API_URL}}
-          KAKAO_AUTH_URL: ${{secrets.KAKAO_AUTH_URL}}
-          SERVICE_URL: ${{secrets.SERVICE_URL}}
-          KEYSTORE_NAME: ${{secrets.KEYSTORE_NAME}}
+          LOCAL_PROPERTIES: ${{ secrets.PROPERTIES }}
 
 
         # Gradle 빌드

--- a/.github/workflows/weekly_dev.yml
+++ b/.github/workflows/weekly_dev.yml
@@ -39,22 +39,10 @@ jobs:
 
       - name: Setup Secret Keys
         run: |
-          echo "KAKAO_REST_API_KEY=\"$KAKAO_REST_API_KEY\"" >> local.properties
-          echo "KAKAO_API_KEY=\"$KAKAO_API_KEY\"" >> local.properties
-          echo "KAKAO_API_KEY_MANIFEST=\"$KAKAO_API_KEY_MANIFEST\"" >> local.properties
-          echo "KAKAO_API_URL=\"$KAKAO_API_URL\"" >> local.properties
-          echo "KAKAO_AUTH_URL=\"$KAKAO_AUTH_URL\"" >> local.properties
-          echo "SERVICE_URL=\"$SERVICE_URL\"" >> local.properties
-          echo "KEYSTORE_NAME=\"$KEYSTORE_NAME\"" >> local.properties
+          echo "$LOCAL_PROPERTIES" >> local.properties
         shell: bash
         env:
-          KAKAO_REST_API_KEY: ${{secrets.KAKAO_REST_API_KEY}}
-          KAKAO_API_KEY: ${{secrets.KAKAO_API_KEY}}
-          KAKAO_API_KEY_MANIFEST: ${{secrets.KAKAO_API_KEY_MANIFEST}}
-          KAKAO_API_URL: ${{secrets.KAKAO_API_URL}}
-          KAKAO_AUTH_URL: ${{secrets.KAKAO_AUTH_URL}}
-          SERVICE_URL: ${{secrets.SERVICE_URL}}
-          KEYSTORE_NAME: ${{secrets.KEYSTORE_NAME}}
+          LOCAL_PROPERTIES: ${{ secrets.PROPERTIES }
 
         # Gradle 스크립트 실행을 위한 권한 설정
       - name: Grant Execute Permission for Gradlew

--- a/.github/workflows/weekly_dev.yml
+++ b/.github/workflows/weekly_dev.yml
@@ -42,7 +42,7 @@ jobs:
           echo "$LOCAL_PROPERTIES" >> local.properties
         shell: bash
         env:
-          LOCAL_PROPERTIES: ${{ secrets.PROPERTIES }
+          LOCAL_PROPERTIES: ${{ secrets.PROPERTIES }}
 
         # Gradle 스크립트 실행을 위한 권한 설정
       - name: Grant Execute Permission for Gradlew

--- a/.github/workflows/weekly_dev.yml
+++ b/.github/workflows/weekly_dev.yml
@@ -37,6 +37,25 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
+      - name: Setup Secret Keys
+        run: |
+          echo "KAKAO_REST_API_KEY=\"$KAKAO_REST_API_KEY\"" >> local.properties
+          echo "KAKAO_API_KEY=\"$KAKAO_API_KEY\"" >> local.properties
+          echo "KAKAO_API_KEY_MANIFEST=\"$KAKAO_API_KEY_MANIFEST\"" >> local.properties
+          echo "KAKAO_API_URL=\"$KAKAO_API_URL\"" >> local.properties
+          echo "KAKAO_AUTH_URL=\"$KAKAO_AUTH_URL\"" >> local.properties
+          echo "SERVICE_URL=\"$SERVICE_URL\"" >> local.properties
+          echo "KEYSTORE_NAME=\"$KEYSTORE_NAME\"" >> local.properties
+        shell: bash
+        env:
+          KAKAO_REST_API_KEY: ${{secrets.KAKAO_REST_API_KEY}}
+          KAKAO_API_KEY: ${{secrets.KAKAO_API_KEY}}
+          KAKAO_API_KEY_MANIFEST: ${{secrets.KAKAO_API_KEY_MANIFEST}}
+          KAKAO_API_URL: ${{secrets.KAKAO_API_URL}}
+          KAKAO_AUTH_URL: ${{secrets.KAKAO_AUTH_URL}}
+          SERVICE_URL: ${{secrets.SERVICE_URL}}
+          KEYSTORE_NAME: ${{secrets.KEYSTORE_NAME}}
+
         # Gradle 스크립트 실행을 위한 권한 설정
       - name: Grant Execute Permission for Gradlew
         run: chmod +x gradlew


### PR DESCRIPTION
## 워크플로에서 Git Secrets 불러오는 스크립트 추가
### ✨ 작업 내용
- 워크플로에 Secret 프로퍼티 참조 코드 추가


## 🔍 참고 사항
Git Secrets 값은 어드민인 테크리더님이 추가해주셔야 합니다.

[해당 링크](https://docs.github.com/ko/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions) 참고하셔서 저희 리포지토리에 시크릿 값들 추가해주세요!

local.properties의 내용들을 `PROPERTIES` 라는 이름의 Secret으로 추가해주시면 됩니다.

```
KAKAO_REST_API_KEY = ""
KAKAO_API_KEY = ""
KAKAO_API_KEY_MANIFEST = ""
KAKAO_API_URL = "https://kapi.kakao.com/"
KAKAO_AUTH_URL = "https://kauth.kakao.com/"
SERVICE_URL = ""
KEYSTORE_NAME = "JeongSanKeyStore"
```

### #️⃣ 연관 이슈(Git Close)
#57
